### PR TITLE
Add missing bindings for Cucumber messages related scenarios

### DIFF
--- a/SpecFlow.TestProjectGenerator/CucumberMessages/TestSuiteSetupDriver.cs
+++ b/SpecFlow.TestProjectGenerator/CucumberMessages/TestSuiteSetupDriver.cs
@@ -52,6 +52,7 @@ namespace TechTalk.SpecFlow.TestProjectGenerator.CucumberMessages
                 }
 
                 _projectsDriver.AddFeatureFile(featureBuilder.ToString());
+                AddGenericWhenStepBinding();
             }
 
             _isProjectCreated = true;


### PR DESCRIPTION
We generate the feature files with a really simple content (only a When step).

However we don't add the bindings for it, therefore during the execution we get the following error:
"TechTalk.SpecFlow.xUnit.SpecFlowPlugin.XUnitPendingStepException : Test pending: No matching step definition found for one or more steps.
... "

This will fix the bindings for both app.config and specflow.json configurations.